### PR TITLE
Ommit display of blank body lines

### DIFF
--- a/examples/tcpsniffer.cr
+++ b/examples/tcpsniffer.cr
@@ -35,8 +35,6 @@ opts = OptionParser.new do |parser|
   parser.on("-h", "--help", "Show help"   ) { puts parser; exit 0 }
 end
 
-WHITESPACE = 2 # Default size for zero data or "" in body mode
-  
 begin
 
   opts.parse!

--- a/examples/tcpsniffer.cr
+++ b/examples/tcpsniffer.cr
@@ -17,6 +17,7 @@ verbose  = false
 dataonly = false
 bodymode = false
 version  = false
+whitespace = false
 
 opts = OptionParser.new do |parser|
   parser.banner = "#{$0} version 0.2.1\n\nUsage: #{$0} [options]"
@@ -29,11 +30,13 @@ opts = OptionParser.new do |parser|
   parser.on("-b", "Body printing mode"    ) { bodymode = true }
   parser.on("-x", "Show hexdump output"   ) { hexdump  = true }
   parser.on("-v", "Show verbose output"   ) { verbose  = true }
+  parser.on("-w", "Remove whitespace packets") { whitespace = true }
   parser.on("--version", "Print the version and exit") { version = true }
   parser.on("-h", "--help", "Show help"   ) { puts parser; exit 0 }
 end
 
 begin
+  WHITESPACE = 2 # Default size for zero data or "".
   opts.parse!
 
   if version
@@ -49,7 +52,11 @@ begin
     next if dataonly && !pkt.tcp_data?
 
     if bodymode
-      if pkt.tcp_data.to_s.inspect.size > 2
+      if whitespace
+        if pkt.tcp_data.to_s.inspect.size > WHITESPACE
+            puts "%s: %s" % [pkt.packet_header, pkt.tcp_data.to_s.inspect]
+        end
+      else
         puts "%s: %s" % [pkt.packet_header, pkt.tcp_data.to_s.inspect]
       end
     else

--- a/examples/tcpsniffer.cr
+++ b/examples/tcpsniffer.cr
@@ -30,13 +30,15 @@ opts = OptionParser.new do |parser|
   parser.on("-b", "Body printing mode"    ) { bodymode = true }
   parser.on("-x", "Show hexdump output"   ) { hexdump  = true }
   parser.on("-v", "Show verbose output"   ) { verbose  = true }
-  parser.on("-w", "Remove whitespace packets") { whitespace = true }
+  parser.on("-w", "We can easily manage White spaces ( diff(1) uses this as ignore all white space)") { whitespace = true }
   parser.on("--version", "Print the version and exit") { version = true }
   parser.on("-h", "--help", "Show help"   ) { puts parser; exit 0 }
 end
 
+WHITESPACE = 2 # Default size for zero data or "" in body mode
+  
 begin
-  WHITESPACE = 2 # Default size for zero data or "".
+
   opts.parse!
 
   if version

--- a/examples/tcpsniffer.cr
+++ b/examples/tcpsniffer.cr
@@ -54,13 +54,8 @@ begin
     next if dataonly && !pkt.tcp_data?
 
     if bodymode
-      if whitespace
-        if pkt.tcp_data.to_s.inspect.size > WHITESPACE
-            puts "%s: %s" % [pkt.packet_header, pkt.tcp_data.to_s.inspect]
-        end
-      else
-        puts "%s: %s" % [pkt.packet_header, pkt.tcp_data.to_s.inspect]
-      end
+       next if whitespace && pkt.tcp_data.to_s =~ /\A\s*\Z/
+       puts "%s: %s" % [pkt.packet_header, pkt.tcp_data.to_s.inspect]
     else
       puts pkt.to_s
       puts "-" * 80     if verbose

--- a/examples/tcpsniffer.cr
+++ b/examples/tcpsniffer.cr
@@ -49,7 +49,9 @@ begin
     next if dataonly && !pkt.tcp_data?
 
     if bodymode
-      puts "%s: %s" % [pkt.packet_header, pkt.tcp_data.to_s.inspect]
+      if pkt.tcp_data.to_s.inspect.size > 2
+        puts "%s: %s" % [pkt.packet_header, pkt.tcp_data.to_s.inspect]
+      end
     else
       puts pkt.to_s
       puts "-" * 80     if verbose


### PR DESCRIPTION
When developing my WIre tool i discovered in body mode that there are blank lines which are a size of 2.

I was thinking maybe implement it in library however feels wrong at the lower level.

This isn't really a pull request its whatever you make / choose todo but for my tool i don't want blank lines in my database.

Just thought i would make you aware of it !

Regards,

Brian
